### PR TITLE
fix prometheus exporter error

### DIFF
--- a/lib/prometheus_exporter/client.rb
+++ b/lib/prometheus_exporter/client.rb
@@ -197,6 +197,13 @@ module PrometheusExporter
       raise
     end
 
+    def wait_for_empty_queue_with_timeout(timeout_seconds)
+      start_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+      while @queue.length > 0
+        break if start_time + timeout_seconds < ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
+        sleep(0.05)
+      end
+    end
   end
 
   class LocalClient < Client
@@ -209,14 +216,6 @@ module PrometheusExporter
 
     def send(json)
       @collector.process(json)
-    end
-  end
-
-  def wait_for_empty_queue_with_timeout(timeout_seconds)
-    start_time = ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-    while @queue.length > 0
-      break if start_time + timeout_seconds < ::Process.clock_gettime(::Process::CLOCK_MONOTONIC)
-      sleep(0.05)
     end
   end
 end


### PR DESCRIPTION
fix for 
```
Feb 27 08:07:40 api1 rbenv[23512]: /var/app/api/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/prometheus_exporter-92fa9ebbb00d/lib/prometheus_exporter/client.rb:125:in `block in stop': undefined method `wait_for_empty_queue_with_timeout' for #<PrometheusExporter::Client:0x00557be3ac0828> (NoMethodError)
Feb 27 08:07:40 api1 rbenv[23512]:         from /var/app/api/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/prometheus_exporter-92fa9ebbb00d/lib/prometheus_exporter/client.rb:124:in `synchronize'
Feb 27 08:07:40 api1 rbenv[23512]:         from /var/app/api/.rbenv/versions/2.4.1/lib/ruby/gems/2.4.0/bundler/gems/prometheus_exporter-92fa9ebbb00d/lib/prometheus_exporter/client.rb:124:in `stop'
Feb 27 08:07:40 api1 rbenv[23512]:         from /var/app/api/releases/c1214b1d0779471c155bc935bdb334f5393bcf73/lib/metrics.rb:26:in `block (2 levels) in client' 
```