### PR TITLE
allow initializing counters

### DIFF
--- a/lib/prometheus_exporter/server/sidekiq_collector.rb
+++ b/lib/prometheus_exporter/server/sidekiq_collector.rb
@@ -13,7 +13,14 @@ module PrometheusExporter::Server
       labels = custom_labels.nil? ? default_labels : default_labels.merge(custom_labels)
 
       ensure_sidekiq_metrics
-      if obj["dead"]
+
+      if obj["init"]
+        @sidekiq_job_duration_seconds.observe(0, labels)
+        @sidekiq_jobs_total.observe(0, labels)
+        @sidekiq_restarted_jobs_total.observe(0, labels)
+        @sidekiq_failed_jobs_total.observe(0, labels)
+        @sidekiq_dead_jobs_total.observe(0, labels)
+      elsif obj["dead"]
         @sidekiq_dead_jobs_total.observe(1, labels)
       else
         @sidekiq_job_duration_seconds.observe(obj["duration"], labels)


### PR DESCRIPTION
as increase from null to 1 is null it is recommended to init counters for all available labels with a 0

[initialise metrics for sidekiq workers](https://trello.com/c/Toyz77Eh/3953-initialise-metrics-for-sidekiq-workers)